### PR TITLE
Feature/header response validation (#16)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -24,6 +24,11 @@
   - [.validateResponse(res, operation)](#validateresponseres-operation)
     - [Parameter: res](#parameter-res)
     - [Parameter: operation](#parameter-operation)
+  - [.validateResponseHeaders(headers, operation, statusCode, setMatchType)](#validateresponseheadersheaders-operation-rescode-setmatchtype)
+    - [Parameter: headers](#parameter-headers)
+    - [Parameter: operation](#parameter-operation-2)
+    - [Parameter: statusCode](#parameter-statuscode)
+    - [Parameter: setMatchType](#parameter-setmatchtype)
   - [.matchOperation(req)](#matchoperationreq)
     - [Parameter: req](#parameter-req)
   - [.register(operationId, handler)](#registeroperationid-handler)
@@ -277,6 +282,54 @@ Type: `any`
 The Operation object or operationId to validate against.
 
 Type: [`Operation`](#operation-object) or `string`
+
+
+### .validateResponseHeaders(headers, operation, resCode, setMatchType)
+
+Validates a response headers and returns the result.
+
+The method will use the pre-compiled Ajv validation schema to validate the given response.
+
+Returns a [ValidationResult object](#validationresult-object).
+
+Example usage:
+```javascript
+const valid = await api.validateResponseHeaders({ 'Content-Type': 'text/plain' }, 'getPetById', 200, 'exact');
+if (valid.errors) {
+  // there were errors
+}
+```
+
+#### Parameter: headers
+
+The response headers to validate.
+
+Type: `any`
+
+#### Parameter: operation
+
+The Operation object or operationId to validate against.
+
+Type: [`Operation`](#operation-object) or `string`
+
+#### Parameter: statusCode
+
+The status code of the response.
+
+Type: `number`
+
+#### Parameter: setMatchType
+
+The type of set matching to perform, in relation with the set of headers defined in your spec. 
+It can be `any`, `superset`, `subset` or `exact`.
+This parameter is optional and defaults to `any`.
+
+- `any`: Skip checks for missing or additional headers. It only checks that the types of the headers are matching with the spec.
+- `superset`: Check that `headers` is a superset of the headers defined in your spec. In other words, you can have headers in `headers` that are described in your spec.
+- `subset`: Check that `headers` is a subset of the headers defined in your spec. In other words, you can have headers in you spec that are not present in `headers`.
+- `exact`: Check that `headers` exactly match the headers defined in your spec.
+
+Type: `string`
 
 ### .matchOperation(req)
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,25 @@ api.register({
 });
 ```
 
+It's also possible to validate the response headers using [`validateResponseHeaders`](https://github.com/anttiviljami/openapi-backend/blob/master/DOCS.md#validateresponseheadersres-operation).
+
+```javascript
+api.register({
+  getPets: (c) => {
+    // when a postResponseHandler is registered, your operation handlers' return value gets passed to context.response
+    return [{ id: 1, name: 'Garfield' }];
+  },
+  postResponseHandler: (c, req, res) => {
+    const valid = c.api.validateResponseHeaders(res.headers, c.operation, res.statusCode, 'exact');
+    if (valid.errors) {
+      // response validation failed
+      return res.status(502).json({ status: 502, err: valid.errors });
+    }
+    return res.status(200).json(c.response);
+  },
+});
+```
+
 ## Mocking API responses
 
 Mocking APIs just got really easy with OpenAPI Backend! Register a [`notImplemented`](https://github.com/anttiviljami/openapi-backend/blob/master/DOCS.md#notimplemented-handler)

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -497,4 +497,23 @@ export class OpenAPIBackend {
   public validateResponse(res: any, operation: Operation | string): ValidationResult {
     return this.validator.validateResponse(res, operation);
   }
+
+  /**
+   * Validates a response and returns the result.
+   *
+   * The method will use the pre-compiled Ajv validation schema to validate a request it.
+   *
+   * Alias for validator.validateResponseHeaders
+   *
+   * @param {*} headers - response to validate
+   * @param {(Operation | string)} [operation]
+   * @param {number} [statusCode]
+   * @param {string} [setMatchType] - one of 'any', 'superset', 'subset', 'exact'
+   * @returns {ValidationStatus}
+   * @memberof OpenAPIBackend
+   */
+  public validateResponseHeaders(headers: any, operation: Operation | string, statusCode: number, setMatchType?: string)
+    : ValidationResult {
+    return this.validator.validateResponseHeaders(headers, operation, statusCode, setMatchType);
+  }
 }


### PR DESCRIPTION
Added docs, tests and implementation for #16.
The code is linting, and all tests are green.

For the regular response validation, I did not add the `content` level because since I did not use a oneof, it seemed odd to add this in the PR.
