### PR TITLE
Restrict to Node 8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "prettier": "prettier --write src/** __tests__/**",
     "toc": "./scripts/generate-toc.js",
     "test": "NODE_ENV=test jest"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["esnext"],
+    "lib": ["es2017"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,


### PR DESCRIPTION
The main reason is to use native async/await instead of down leveling to
provide better debugging experience.

1. Technically this is a breaking change. Maybe it needs a major version bump?
2. Probably need to mentioned somewhere in `README` or `DOCS` that library requires Node 8+. What would be a good place for it?

Fixes #26 
