### PR TITLE
Include the status code in the api to pass to validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-backend",
   "description": "Build, Validate, Route, and Mock using OpenAPI specification. Framework-agnostic",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "author": "Viljami Kuosmanen <viljami@avoinsorsa.fi>",
   "license": "MIT",
   "keywords": [

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -493,11 +493,12 @@ export class OpenAPIBackend {
    *
    * @param {*} res - response to validate
    * @param {(Operation | string)} [operation]
+   * @param {number} status
    * @returns {ValidationStatus}
    * @memberof OpenAPIBackend
    */
-  public validateResponse(res: any, operation: Operation | string): ValidationResult {
-    return this.validator.validateResponse(res, operation);
+  public validateResponse(res: any, operation: Operation | string, statusCode?: number): ValidationResult {
+    return this.validator.validateResponse(res, operation, statusCode);
   }
 
   /**


### PR DESCRIPTION
It looks like this was missed in the latest PR changes made to the validator. The current workaround that I've found is to do something like the following to bypass the api:
```
function postResponseHandler(c, ctx) {
  const valid = c.api.validator.validateResponse(ctx.body, c.operation, ctx.status);

  // ...
});
```