### PR TITLE
Use loaded document to dereference

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -183,7 +183,7 @@ export class OpenAPIBackend {
       }
 
       // dereference the document into definition (make sure not to copy)
-      this.definition = await SwaggerParser.dereference(this.inputDocument);
+      this.definition = await SwaggerParser.dereference(this.document || this.inputDocument);
     } catch (err) {
       if (this.strict) {
         // in strict-mode, fail hard and re-throw the error


### PR DESCRIPTION
In case we're running not in `quick` mode we're reading definition twice since it's already loaded and parsed.
This PR checks if `document` is already loaded and use it or read input document one more time to make `definition`.