### PR TITLE
Refactored the orderBy function to find matching operation in router

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -124,7 +124,7 @@ export class OpenAPIRouter {
     // find matching operation
     const match = _.chain(templatePathMatches)
       // order matches by length (specificity)
-      .orderBy((op) => op.path.length, 'desc')
+      .orderBy((op) => op.path.replace(RegExp(/\{.*?\}/g), '').length, 'desc')
       // then check if one of the matched operations matches the method
       .find(({ method }) => method === req.method)
       .value();


### PR DESCRIPTION
**Issue:**
`Lets say` there are two operations with paths **_"/parties/{ID}/error"_** and **_"/parties/{ID}/{SubID}"_** exist in the openapi specification. The request with path **_"/parties/123/error"_** is not being matched with the correct operationId.

**Expected behaviour:**
The request path _"/parties/123/error"_ should be matched with _"/parties/{ID}/error"_

**Current behaviour:**
The request path _"/parties/123/error"_ is being matched with _"/parties/{ID}/{SubID}"_

**Fix**
The matched array can be sorted based on the number of variables in the path. The path with least number of variables can be picked up.