### PR TITLE
Pass base path to dereference function

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -183,7 +183,7 @@ export class OpenAPIBackend {
       }
 
       // dereference the document into definition (make sure not to copy)
-      this.definition = await SwaggerParser.dereference(this.document || this.inputDocument);
+      this.definition = await SwaggerParser.dereference(this.inputDocument, this.document || this.inputDocument);
     } catch (err) {
       if (this.strict) {
         // in strict-mode, fail hard and re-throw the error

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -183,7 +183,11 @@ export class OpenAPIBackend {
       }
 
       // dereference the document into definition (make sure not to copy)
-      this.definition = await SwaggerParser.dereference(this.inputDocument, this.document || this.inputDocument);
+      if (typeof this.inputDocument === 'string') {
+        this.definition = await SwaggerParser.dereference(this.inputDocument, this.document || this.inputDocument);
+      } else {
+        this.definition = await SwaggerParser.dereference(this.document || this.inputDocument);
+      }
     } catch (err) {
       if (this.strict) {
         // in strict-mode, fail hard and re-throw the error

--- a/src/types/swagger-parser.d.ts
+++ b/src/types/swagger-parser.d.ts
@@ -25,5 +25,6 @@ declare module 'swagger-parser' {
   function parse(api: string | Document, options?: Options): Promise<Document>;
   function validate(api: string | Document, options?: Options): Promise<Document>;
   function dereference(api: string | Document, options?: Options): Promise<Document>;
+  function dereference(basePath: string, api: string | Document, options?: Options): Promise<Document>;
   function bundle(api: string | Document, options?: Options): Promise<Document>;
 }


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/anttiviljami/openapi-backend/pull/97#issuecomment-683420629. Specifying a base path is officially supported in `swagger-parser`, but their docs don't mention it. However, the type signature (https://github.com/APIDevTools/swagger-parser/blob/5f0c6250af5346d10bb2cd8533598a42f3cc73e5/lib/index.d.ts#L76-L78) does:

```ts
public dereference(api: string | OpenAPI.Document): Promise<OpenAPI.Document>; // used before
public dereference(baseUrl: string, api: string | OpenAPI.Document, options: SwaggerParser.Options): Promise<OpenAPI.Document>; // used now
```