### PR TITLE
Copy handlers passed to constructor instead of mutating passed objects

### DIFF
--- a/src/backend.test.ts
+++ b/src/backend.test.ts
@@ -130,6 +130,27 @@ describe('OpenAPIBackend', () => {
     expect(api.router.getOperations()).toHaveLength(0);
   });
 
+  test('copies objects passed to constructor', async () => {
+    // Create an OpenAPIBackend and pass handlers and securityHandlers which must not be mutated.
+    // This avoids overwriting shared default handlers if creating multiple instances of OpenAPIBackend.
+    const handlers = Object.freeze({}) as any;
+    const securityHandlers = Object.freeze({}) as any;
+    const dummyHandler = jest.fn();
+
+    const api = new OpenAPIBackend({ definition, handlers, securityHandlers });
+    await api.init();
+
+    // Verify that passed handlers object is not mutated (even though using Object.freeze already verifies this)
+    api.registerHandler('getPets', dummyHandler);
+    expect(api.handlers['getPets']).toBeDefined();
+    expect(handlers['getPets']).toBeUndefined();
+
+    // Verify that passed securityHandlers object is not mutated (even though using Object.freeze already verifies this)
+    api.registerSecurityHandler('basicAuth', dummyHandler)
+    expect(api.securityHandlers['basicAuth']).toBeDefined();
+    expect(securityHandlers['basicAuth']).toBeUndefined();
+  });
+
   describe('.register', () => {
     const api = new OpenAPIBackend({ definition });
     beforeAll(() => api.init());

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -147,8 +147,8 @@ export class OpenAPIBackend {
     this.strict = optsWithDefaults.strict;
     this.quick = optsWithDefaults.quick;
     this.validate = optsWithDefaults.validate;
-    this.handlers = optsWithDefaults.handlers;
-    this.securityHandlers = optsWithDefaults.securityHandlers;
+    this.handlers = {...optsWithDefaults.handlers}; // Copy to avoid mutating passed object
+    this.securityHandlers = {...optsWithDefaults.securityHandlers}; // Copy to avoid mutating passed object
     this.ajvOpts = optsWithDefaults.ajvOpts;
     this.customizeAjv = optsWithDefaults.customizeAjv;
   }


### PR DESCRIPTION
The handlers and securityHandlers objects passed to OpenAPIBackend's
constructor was stored as properties and later mutated (e.g. if registering
handlers separately). This could cause problems if passing a default set of
handlers to multiple instances of OpenAPIBackend, since it would then be
shared by all instances, hence overwritten with very confusing results.

Copying these objects instead to allow passing handlers objects that
aren't mutated, which also allows declaring them as constants (e.g. by using
Object.freeze).