### PR TITLE
enables compiling recursive schemas with ajv

### DIFF
--- a/__tests__/resources/refs.openapi.json
+++ b/__tests__/resources/refs.openapi.json
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Circular References",
+    "description": "API with circular references",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/trees": {
+			"post": {
+				"operationId": "createTree",
+				"responses": { 
+					"200": { 
+						"description": "ok" 
+					} 
+				},
+				"requestBody": { 
+					"$ref": "#/components/requestBodies/CreateTree" 
+				}
+			},
+			"get": {
+				"operationId": "getTrees",
+				"responses": { 
+					"200": { 
+						"$ref": "#/components/schemas/BinTree"
+					} 
+				},
+				"parameters": [
+					{
+						"name": "subtree",
+						"in": "query",
+						"description": "Filter trees by existance of a subtree",
+						"required": false,
+						"schema": {
+							"$ref": "#/components/schemas/BinTree"
+						}
+					}
+				]
+			}
+    }
+  },
+  "components": {
+    "schemas": {
+			"BinTree": {
+				"title": "BinTree",
+				"type": "object",
+				"nullable": true,
+				"properties": {
+					"left": { 
+						"nullable": true,
+						"allOf": [{ "$ref": "#/components/schemas/BinTree" }]
+					},
+					"right": { 
+						"nullable": true,
+						"allOf": [{ "$ref": "#/components/schemas/BinTree" }]
+					},
+					"value": {
+						"type": "number"
+					}
+				}
+			}
+		},
+		"requestBodies": {
+			"CreateTree": {
+				"content": {
+					"application/json": {
+						"schema": { "$ref": "#/components/schemas/BinTree" }
+					}
+				}
+			}
+		}
+  }
+}

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -448,7 +448,7 @@ describe('OpenAPIValidator', () => {
 					},
 				});
 			})
-      
+
       test('passes validation for POST /pets with full object', async () => {
         const valid = validator.validateRequest({
           path: '/pets',

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -402,7 +402,7 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
     });
 
     describe('request payloads', () => {
-			let validator: OpenAPIValidator;
+      let validator: OpenAPIValidator;
       const petSchema: SchemaLike = {
         type: 'object',
         additionalProperties: false,
@@ -417,46 +417,44 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
         },
         required: ['name'],
       };
-			beforeAll(() => {
-				validator = new OpenAPIValidator({
-					definition: {
-						...meta,
-						paths: {
-							'/pets': {
-								post: {
-									operationId: 'createPet',
-									responses: { 200: { description: 'ok' } },
-									requestBody: {
-										content: {
-											'application/json': {
-												schema: petSchema,
-											},
-										},
-									},
-								},
-								put: {
-									operationId: 'replacePet',
-									responses: { 200: { description: 'ok' } },
-									requestBody: {
-										content: {
-											'application/json': {
-												schema: petSchema,
-											},
-											'application/xml': {
-												example: '<Pet><name>string</name></Pet>',
-											},
-										},
-									},
-								},
-							},
-							...circularRefDefinition.paths,
+      beforeAll(() => {
+        validator = new OpenAPIValidator({
+          definition: {
+            ...meta,
+            paths: {
+              '/pets': {
+                post: {
+                  operationId: 'createPet',
+                  responses: { 200: { description: 'ok' } },
+                  requestBody: {
+                    content: {
+                      'application/json': {
+                        schema: petSchema,
+                      },
+                    },
+                  },
+                },
+                put: {
+                  operationId: 'replacePet',
+                  responses: { 200: { description: 'ok' } },
+                  requestBody: {
+                    content: {
+                      'application/json': {
+                        schema: petSchema,
+                      },
+                      'application/xml': {
+                        example: '<Pet><name>string</name></Pet>',
+                      },
+                    },
+                  },
+                },
+              },
+              ...circularRefDefinition.paths,
             },
             ...constructorOpts,
-
           },
-          
-				});
-			})
+        });
+      });
 
       test('passes validation for POST /pets with full object', async () => {
         const valid = validator.validateRequest({

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -4,6 +4,12 @@ import { OpenAPIV3 } from 'openapi-types';
 import { SchemaLike } from 'mock-json-schema';
 import { SetMatchType } from './backend';
 import { ValidationContext } from './validation';
+import SwaggerParser = require('swagger-parser');
+import * as path from 'path';
+import * as _ from 'lodash';
+import { before } from 'lodash';
+const testsDir = path.join(__dirname, '..', '__tests__');
+const circularRefPath = path.join(testsDir, 'resources', 'refs.openapi.json');
 
 const headers = { accept: 'application/json' };
 
@@ -14,6 +20,34 @@ const meta = {
     version: '1.0.0',
   },
 };
+
+const validBTree = {
+  left: {
+    left: null,
+    right: null,
+    value: 0,
+  },
+  right: {
+    left: null,
+    right: {
+      left: null,
+      right: null,
+      value: 3,
+    },
+    value: 2,
+  },
+  value: 1,
+};
+const invalidBTree = {
+  left: null,
+  right: null,
+  value: 'not a number',
+};
+
+let circularRefDefinition: OpenAPIV3.Document;
+beforeAll(async () => {
+  circularRefDefinition = await SwaggerParser.dereference(circularRefPath);
+});
 
 describe('OpenAPIValidator', () => {
   describe('.validateRequest', () => {
@@ -362,6 +396,7 @@ describe('OpenAPIValidator', () => {
     });
 
     describe('request payloads', () => {
+			let validator: OpenAPIValidator;
       const petSchema: SchemaLike = {
         type: 'object',
         additionalProperties: false,
@@ -376,42 +411,44 @@ describe('OpenAPIValidator', () => {
         },
         required: ['name'],
       };
-
-      const validator = new OpenAPIValidator({
-        definition: {
-          ...meta,
-          paths: {
-            '/pets': {
-              post: {
-                operationId: 'createPet',
-                responses: { 200: { description: 'ok' } },
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: petSchema,
-                    },
-                  },
-                },
-              },
-              put: {
-                operationId: 'replacePet',
-                responses: { 200: { description: 'ok' } },
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: petSchema,
-                    },
-                    'application/xml': {
-                      example: '<Pet><name>string</name></Pet>',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
-
+			beforeAll(() => {
+				validator = new OpenAPIValidator({
+					definition: {
+						...meta,
+						paths: {
+							'/pets': {
+								post: {
+									operationId: 'createPet',
+									responses: { 200: { description: 'ok' } },
+									requestBody: {
+										content: {
+											'application/json': {
+												schema: petSchema,
+											},
+										},
+									},
+								},
+								put: {
+									operationId: 'replacePet',
+									responses: { 200: { description: 'ok' } },
+									requestBody: {
+										content: {
+											'application/json': {
+												schema: petSchema,
+											},
+											'application/xml': {
+												example: '<Pet><name>string</name></Pet>',
+											},
+										},
+									},
+								},
+							},
+							...circularRefDefinition.paths,
+						},
+					},
+				});
+			})
+      
       test('passes validation for POST /pets with full object', async () => {
         const valid = validator.validateRequest({
           path: '/pets',
@@ -435,6 +472,26 @@ describe('OpenAPIValidator', () => {
           },
         });
         expect(valid.errors).toBeFalsy();
+      });
+
+      test('passes validation for POST /trees with tree of numbers (recursive structure)', async () => {
+        const valid = validator.validateRequest({
+          path: '/trees',
+          method: 'post',
+          headers,
+          body: validBTree,
+        });
+        expect(valid.errors).toBeFalsy();
+      });
+
+      test('fails validation for POST /trees with tree of strings (recursive structure)', async () => {
+        const valid = validator.validateRequest({
+          path: '/trees',
+          method: 'post',
+          headers,
+          body: invalidBTree,
+        });
+        expect(valid.errors).toHaveLength(1);
       });
 
       test('passes validation for POST /pets with nullable age', async () => {

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -4,7 +4,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { SchemaLike } from 'mock-json-schema';
 import { SetMatchType } from './backend';
 import { ValidationContext } from './validation';
-import SwaggerParser = require('swagger-parser');
+import { dereference } from '@apidevtools/json-schema-ref-parser';
 import * as path from 'path';
 import * as _ from 'lodash';
 import { before } from 'lodash';
@@ -44,12 +44,11 @@ const invalidBTree = {
   value: 'not a number',
 };
 
-let circularRefDefinition: OpenAPIV3.Document;
+let circularRefDefinition: any;
 beforeAll(async () => {
-  circularRefDefinition = await SwaggerParser.dereference(circularRefPath);
+  circularRefDefinition = await dereference(circularRefPath);
 });
 
-describe('OpenAPIValidator', () => {
 describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts %j', (constructorOpts) => {
   describe('.validateRequest', () => {
     describe('path params in path base object', () => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -460,7 +460,7 @@ export class OpenAPIValidator {
     return (function derez(value, path) {
       // The derez function recurses through the object, producing the deep copy.
 
-      let old_path; // The path of an earlier occurance of value
+      let oldPath; // The path of an earlier occurance of value
       let nu: any; // The new object or array
 
       // typeof null === "object", so go on if this value is really an object but not
@@ -479,9 +479,9 @@ export class OpenAPIValidator {
         // encountered it. If so, return a {"$ref":PATH} object. This uses an
         // ES6 WeakMap.
 
-        old_path = objects.get(value);
-        if (old_path !== undefined) {
-          return { $ref: old_path };
+        oldPath = objects.get(value);
+        if (oldPath !== undefined) {
+          return { $ref: oldPath };
         }
 
         // Otherwise, accumulate the unique value and its path.
@@ -492,13 +492,13 @@ export class OpenAPIValidator {
 
         if (Array.isArray(value)) {
           nu = [];
-          value.forEach(function (element, i) {
+          value.forEach((element, i) => {
             nu[i] = derez(element, path + '/' + i);
           });
         } else {
           // If it is an object, replicate the object.
           nu = {};
-          Object.keys(value).forEach(function (name) {
+          Object.keys(value).forEach((name) => {
             nu[name] = derez(value[name], path + '/' + name);
           });
         }


### PR DESCRIPTION
Adds a function to clone and transform schemas before compiling them in Ajv which replaces circular references with JSON refs. Ajv will fail for schemas with recursive references because it stringifies them. However, Ajv will handle JSONSchema refs just fine.  
In reference to: #116 