### PR TITLE
Add option to lazy compile Ajv validators

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -58,6 +58,7 @@
     - [Parameter: opts.definition](#parameter-optsdefinition)
     - [Parameter: opts.ajvOpts](#parameter-optsajvopts)
     - [Parameter: opts.router](#parameter-optsrouter)
+    - [Parameter: opts.lazyCompileValidators](#parameter-optslazycompilevalidators)
     - [Parameter: opts.customizeAjv(originalAjv, ajvOpts, validationContext)](#parameter-optscustomizeajvoriginalajv-ajvopts-validationcontext)
   - [.validateRequest(req, operation?)](#validaterequestreq-operation)
     - [Parameter: req](#parameter-req)
@@ -588,6 +589,7 @@ const validator = new OpenAPIValidator({
   definition: api.document,
   router: new OpenAPIRouter()
   ajvOpts: { unknownFormats: true },
+  lazyCompileValidators: false,
   customizeAjv: (originalAjv, ajvOpts, validationContext) => new Ajv(),
 });
 ```
@@ -629,6 +631,14 @@ Type: `Ajv.Options`
 Optional. Passed instance of OpenAPIRouter. Will create new instance from definition object if not passed.
 
 Type: [`OpenAPIRouter`](#class-openapirouter)
+
+#### Parameter: opts.lazyCompileValidators
+
+Optional. When set to `true` skips precompiling Ajv validators and compiles only when needed. Useful for optimizing for init time e.g. in Lambda.
+
+This option is applied when the [OpenAPIBackend `quick` parameter](#parameter-optsquick) is set to `true`.
+
+Type: `Boolean`
 
 #### Parameter: opts.customizeAjv(originalAjv, ajvOpts, validationContext)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: [ '**/?(*.)+(spec|test).ts?(x)' ],
-  testPathIgnorePatterns: [ 'node_modules', 'examples' ]
+  testPathIgnorePatterns: [ 'node_modules', 'examples' ],
+  verbose: true,
+  silent: true
 };

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -208,6 +208,7 @@ export class OpenAPIBackend {
         ajvOpts: this.ajvOpts,
         customizeAjv: this.customizeAjv,
         router: this.router,
+        lazyCompileValidators: Boolean(this.quick), // optimise startup by lazily compiling Ajv validators
       });
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { Operation } from './router';
 
 export default class OpenAPIUtils {
   /**
@@ -72,5 +73,21 @@ export default class OpenAPIUtils {
       status: Number(code),
       res: obj[code],
     };
+  }
+
+  /**
+   * Get operationId, (or generate one) for an operation
+   *
+   * @static
+   * @param {Operation} operation
+   * @returns {string} OperationId of the given operation
+   * @memberof OpenAPIUtils
+   */
+  public static getOperationId(operation: Operation): string {
+    if (!operation?.operationId) {
+      // TODO: generate a default substitute for operationId
+      return `unknown`;
+    }
+    return operation.operationId;
   }
 }

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -15,7 +15,7 @@ const meta = {
   },
 };
 
-describe('OpenAPIValidator', () => {
+describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts %j', (constructorOpts) => {
   describe('.validateRequest', () => {
     describe('path params in path base object', () => {
       const validator = new OpenAPIValidator({
@@ -45,6 +45,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for GET /pets/1', async () => {
@@ -112,6 +113,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for GET /pets/1', async () => {
@@ -152,6 +154,7 @@ describe('OpenAPIValidator', () => {
       const validator = new OpenAPIValidator({
         definition,
         router: new OpenAPIRouter({ definition, apiRoot: '/v1' }),
+        ...constructorOpts,
       });
 
       test('passes validation for GET /v1/pets/1', async () => {
@@ -192,6 +195,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for GET /pets', async () => {
@@ -269,6 +273,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for GET /pets?limit=10', async () => {
@@ -331,6 +336,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for GET /secret, x-api-key:abcd0123', async () => {
@@ -410,6 +416,7 @@ describe('OpenAPIValidator', () => {
             },
           },
         },
+        ...constructorOpts,
       });
 
       test('passes validation for POST /pets with full object', async () => {
@@ -594,6 +601,7 @@ describe('OpenAPIValidator', () => {
           },
         },
       },
+      ...constructorOpts,
     });
 
     test('passes validation with valid 200 response object and operationId getPetById', async () => {
@@ -859,6 +867,7 @@ describe('OpenAPIValidator', () => {
           },
         },
       },
+      ...constructorOpts,
     });
 
     test('passes validation with valid header object and operationId listPets, no options', async () => {
@@ -1178,6 +1187,7 @@ describe('OpenAPIValidator', () => {
               ...meta,
               paths,
             },
+            ...constructorOpts,
           });
         expect(construct()).toBeInstanceOf(OpenAPIValidator);
         expect(console.warn).not.toBeCalled();
@@ -1190,6 +1200,7 @@ describe('OpenAPIValidator', () => {
             ...meta,
             paths,
           },
+          ...constructorOpts,
         });
         const valid = validator.validateRequest({
           path: '/pets',
@@ -1214,6 +1225,7 @@ describe('OpenAPIValidator', () => {
             ...meta,
             paths,
           },
+          ...constructorOpts,
         });
         const valid = validator.validateRequest({
           path: '/pets',
@@ -1232,6 +1244,7 @@ describe('OpenAPIValidator', () => {
             ...meta,
             paths,
           },
+          ...constructorOpts,
         });
         const valid = validator.validateRequest({
           path: '/pets',
@@ -1250,6 +1263,7 @@ describe('OpenAPIValidator', () => {
             ...meta,
             paths,
           },
+          ...constructorOpts,
         });
         const valid = validator.validateRequest({
           path: '/pets',
@@ -1263,7 +1277,9 @@ describe('OpenAPIValidator', () => {
       });
     });
   });
+});
 
+describe('OpenAPIValidator', () => {
   describe('customizeAjv', () => {
     describe('using custom formats', () => {
       const paths: OpenAPIV3.PathsObject = {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -55,10 +55,6 @@ interface StatusBasedResponseValidatorsFunctionMap {
   [statusCode: string]: Ajv.ValidateFunction;
 }
 
-interface ResponseValidatorsFunctionMap {
-  [operationId: string]: StatusBasedResponseValidatorsFunctionMap;
-}
-
 export enum ValidationContext {
   RequestBody = 'requestBodyValidator',
   Params = 'paramsValidator',
@@ -128,12 +124,13 @@ const defaultFormats: Record<string, Ajv.FormatDefinition> = {
 export class OpenAPIValidator {
   public definition: Document;
   public ajvOpts: Ajv.Options;
+  public lazyCompileValidators: boolean;
   public customizeAjv: AjvCustomizer | undefined;
 
-  public requestValidators: { [operationId: string]: Ajv.ValidateFunction[] };
-  public responseValidators: { [operationId: string]: Ajv.ValidateFunction };
-  public statusBasedResponseValidators: ResponseValidatorsFunctionMap;
-  public responseHeadersValidators: { [operationId: string]: ResponseHeadersValidateFunctionMap };
+  public requestValidators: { [operationId: string]: Ajv.ValidateFunction[] | null };
+  public responseValidators: { [operationId: string]: Ajv.ValidateFunction | null };
+  public statusBasedResponseValidators: { [operationId: string]: StatusBasedResponseValidatorsFunctionMap | null };
+  public responseHeadersValidators: { [operationId: string]: ResponseHeadersValidateFunctionMap | null };
 
   public router: OpenAPIRouter;
 
@@ -142,14 +139,16 @@ export class OpenAPIValidator {
    *
    * @param opts - constructor options
    * @param {Document | string} opts.definition - the OpenAPI definition, file path or Document object
-   * @param {boolean} opts.ajvOpts - default ajv constructor opts (default: { unknownFormats: 'ignore' })
+   * @param {object} opts.ajvOpts - default ajv constructor opts (default: { unknownFormats: 'ignore' })
    * @param {OpenAPIRouter} opts.router - passed instance of OpenAPIRouter. Will create own child if no passed
+   * @param {boolean} opts.lazyCompileValidators - skips precompiling Ajv validators and compiles only when needed
    * @memberof OpenAPIRequestValidator
    */
   constructor(opts: {
     definition: Document;
     ajvOpts?: Ajv.Options;
     router?: OpenAPIRouter;
+    lazyCompileValidators?: boolean;
     customizeAjv?: AjvCustomizer;
   }) {
     this.definition = opts.definition;
@@ -165,24 +164,58 @@ export class OpenAPIValidator {
     // initalize router
     this.router = opts.router || new OpenAPIRouter({ definition: this.definition });
 
-    // get defined api operations
-    const operations = this.router.getOperations();
-
-    // build request validation schemas for api operations
+    // initialize validator stores
     this.requestValidators = {};
-    operations.map(this.buildRequestValidatorsForOperation.bind(this));
-
-    // build response validation schemas for api operations
     this.responseValidators = {};
-    operations.map(this.buildResponseValidatorForOperation.bind(this));
-
-    // build response validation schemas for api operations, per status code
     this.statusBasedResponseValidators = {};
-    operations.map(this.buildStatusBasedResponseValidatorForOperation.bind(this));
-
-    // build response header validation schemas for api operations
     this.responseHeadersValidators = {};
-    operations.map(this.buildResponseHeadersValidatorForOperation.bind(this));
+
+    // precompile validators if not in lazy mode
+    if (!opts.lazyCompileValidators) {
+      this.preCompileRequestValidators();
+      this.preCompileResponseValidators();
+      this.preCompileResponseHeaderValidators();
+    }
+  }
+
+  /**
+   * Pre-compiles Ajv validators for requests of all api operations
+   *
+   * @memberof OpenAPIValidator
+   */
+  public preCompileRequestValidators(): void {
+    const operations = this.router.getOperations();
+    for (const operation of operations) {
+      const operationId = OpenAPIUtils.getOperationId(operation);
+      this.requestValidators[operationId] = this.buildRequestValidatorsForOperation(operation);
+    }
+  }
+
+  /**
+   * Pre-compiles Ajv validators for responses of all api operations
+   *
+   * @memberof OpenAPIValidator
+   */
+  public preCompileResponseValidators(): void {
+    const operations = this.router.getOperations();
+    for (const operation of operations) {
+      const operationId = OpenAPIUtils.getOperationId(operation);
+      this.responseValidators[operationId] = this.buildResponseValidatorForOperation(operation);
+      this.statusBasedResponseValidators[operationId] = this.buildStatusBasedResponseValidatorForOperation(operation);
+    }
+  }
+
+  /**
+   * Pre-compiles Ajv validators for response headers of all api operations
+   *
+   * @memberof OpenAPIValidator
+   */
+  public preCompileResponseHeaderValidators(): void {
+    const operations = this.router.getOperations();
+    for (const operation of operations) {
+      const operationId = OpenAPIUtils.getOperationId(operation);
+      this.responseHeadersValidators[operationId] = this.buildResponseHeadersValidatorForOperation(operation);
+    }
   }
 
   /**
@@ -212,7 +245,7 @@ export class OpenAPIValidator {
 
     // get pre-compiled ajv schemas for operation
     const { operationId } = operation;
-    const validators = this.getRequestValidatorsForOperation(operationId);
+    const validators = this.getRequestValidatorsForOperation(operationId) || [];
 
     // build a parameter object to validate
     const { params, query, headers, cookies, requestBody } = this.router.parseRequest(req, operation);
@@ -303,7 +336,7 @@ export class OpenAPIValidator {
 
     const { operationId } = op;
 
-    let validate: Ajv.ValidateFunction | undefined;
+    let validate: Ajv.ValidateFunction | null = null;
     if (statusCode) {
       // use specific status code
       const validateMap = this.getStatusBasedResponseValidatorForOperation(operationId);
@@ -372,7 +405,7 @@ export class OpenAPIValidator {
     }
 
     const { operationId } = op;
-    const validateMap: ResponseHeadersValidateFunctionMap = this.getResponseHeadersValidatorForOperation(operationId);
+    const validateMap = this.getResponseHeadersValidatorForOperation(operationId);
 
     if (validateMap) {
       let validateForStatus: { [setMatchType: string]: Ajv.ValidateFunction };
@@ -409,47 +442,29 @@ export class OpenAPIValidator {
    * Get an array of request validator functions for an operation by operationId
    *
    * @param {string} operationId
-   * @returns {Ajv.ValidateFunction[]}
-   * @memberof OpenAPIRequestValidator
-   */
-  public getRequestValidatorsForOperation(operationId: string) {
-    return this.requestValidators[operationId];
-  }
-
-  /**
-   * Get Ajv options
-   *
-   * @param {ValidationContext} validationContext
-   * @param {Ajv.Options} [opts={}]
-   * @returns Ajv
+   * @returns {*}  {(Ajv.ValidateFunction[] | null)}
    * @memberof OpenAPIValidator
    */
-  public getAjv(validationContext: ValidationContext, opts: Ajv.Options = {}) {
-    const ajvOpts = { ...this.ajvOpts, ...opts };
-    const ajv = new Ajv(ajvOpts);
-
-    for (const [name, format] of Object.entries(defaultFormats)) {
-      ajv.addFormat(name, format);
+  public getRequestValidatorsForOperation(operationId: string) {
+    if (this.requestValidators[operationId] === undefined) {
+      const operation = this.router.getOperation(operationId) as Operation;
+      this.requestValidators[operationId] = this.buildRequestValidatorsForOperation(operation);
     }
-
-    if (this.customizeAjv) {
-      return this.customizeAjv(ajv, ajvOpts, validationContext);
-    }
-    return ajv;
+    return this.requestValidators[operationId];
   }
 
   /**
    * Builds Ajv request validation functions for an operation and registers them to requestValidators
    *
    * @param {Operation} operation
-   * @memberof OpenAPIRequestValidator
+   * @returns {*}  {(Ajv.ValidateFunction[] | null)}
+   * @memberof OpenAPIValidator
    */
-  public buildRequestValidatorsForOperation(operation: Operation): void {
-    if (!operation || !operation.operationId) {
+  public buildRequestValidatorsForOperation(operation: Operation): Ajv.ValidateFunction[] | null {
+    if (!operation?.operationId) {
       // no operationId, don't register a validator
-      return;
+      return null;
     }
-    const { operationId } = operation;
 
     // validator functions for this operation
     const validators: Ajv.ValidateFunction[] = [];
@@ -540,17 +555,21 @@ export class OpenAPIValidator {
     // add compiled params schema to requestValidators for this operation id
     const paramsValidator = this.getAjv(ValidationContext.Params, { coerceTypes: true });
     validators.push(paramsValidator.compile(paramsSchema));
-    this.requestValidators[operationId] = validators;
+    return validators;
   }
 
   /**
    * Get response validator function for an operation by operationId
    *
    * @param {string} operationId
-   * @returns {Ajv.ValidateFunction}
-   * @memberof OpenAPIRequestValidator
+   * @returns {*}  {(Ajv.ValidateFunction | null)}
+   * @memberof OpenAPIValidator
    */
   public getResponseValidatorForOperation(operationId: string) {
+    if (this.responseValidators[operationId] === undefined) {
+      const operation = this.router.getOperation(operationId) as Operation;
+      this.responseValidators[operationId] = this.buildResponseValidatorForOperation(operation);
+    }
     return this.responseValidators[operationId];
   }
 
@@ -558,19 +577,19 @@ export class OpenAPIValidator {
    * Builds an ajv response validator function for an operation and registers it to responseValidators
    *
    * @param {Operation} operation
-   * @memberof OpenAPIRequestValidator
+   * @returns {*}  {(Ajv.ValidateFunction | null)}
+   * @memberof OpenAPIValidator
    */
-  public buildResponseValidatorForOperation(operation: Operation): void {
+  public buildResponseValidatorForOperation(operation: Operation): Ajv.ValidateFunction | null {
     if (!operation || !operation.operationId) {
       // no operationId, don't register a validator
-      return;
+      return null;
     }
     if (!operation.responses) {
       // operation has no responses, don't register a validator
-      return;
+      return null;
     }
 
-    const { operationId } = operation;
     const responseSchemas: OpenAPIV3.SchemaObject[] = [];
 
     _.mapKeys(operation.responses, (res, status) => {
@@ -583,23 +602,27 @@ export class OpenAPIValidator {
 
     if (_.isEmpty(responseSchemas)) {
       // operation has no response schemas, don't register a validator
-      return;
+      return null;
     }
 
     // compile the validator function and register to responseValidators
     const schema = { oneOf: responseSchemas };
     const responseValidator = this.getAjv(ValidationContext.Response);
-    this.responseValidators[operationId] = responseValidator.compile(schema);
+    return responseValidator.compile(schema);
   }
 
   /**
    * Get response validator function for an operation by operationId
    *
    * @param {string} operationId
-   * @returns {Object.<Ajv.ValidateFunction>}}
+   * @returns {*}  {(StatusBasedResponseValidatorsFunctionMap | null)}
    * @memberof OpenAPIRequestValidator
    */
-  public getStatusBasedResponseValidatorForOperation(operationId: string): StatusBasedResponseValidatorsFunctionMap {
+  public getStatusBasedResponseValidatorForOperation(operationId: string) {
+    if (this.statusBasedResponseValidators[operationId] === undefined) {
+      const operation = this.router.getOperation(operationId) as Operation;
+      this.statusBasedResponseValidators[operationId] = this.buildStatusBasedResponseValidatorForOperation(operation);
+    }
     return this.statusBasedResponseValidators[operationId];
   }
 
@@ -607,19 +630,20 @@ export class OpenAPIValidator {
    * Builds an ajv response validator function for an operation and registers it to responseHeadersValidators
    *
    * @param {Operation} operation
-   * @memberof OpenAPIRequestValidator
+   * @returns {*}  {(StatusBasedResponseValidatorsFunctionMap | null)}
+   * @memberof OpenAPIValidator
    */
-  public buildStatusBasedResponseValidatorForOperation(operation: Operation): void {
+  public buildStatusBasedResponseValidatorForOperation(
+    operation: Operation,
+  ): StatusBasedResponseValidatorsFunctionMap | null {
     if (!operation || !operation.operationId) {
       // no operationId, don't register a validator
-      return;
+      return null;
     }
     if (!operation.responses) {
       // operation has no responses, don't register a validator
-      return;
+      return null;
     }
-    const { operationId } = operation;
-
     const responseValidators: StatusBasedResponseValidatorsFunctionMap = {};
     const validator = this.getAjv(ValidationContext.Response);
 
@@ -632,37 +656,41 @@ export class OpenAPIValidator {
       return null;
     });
 
-    this.statusBasedResponseValidators[operationId as string] = responseValidators;
+    return responseValidators;
   }
 
   /**
    * Get response validator function for an operation by operationId
    *
    * @param {string} operationId
-   * @returns {Object.<Object.<Ajv.ValidateFunction>>}}
+   * @returns {*}  {(ResponseHeadersValidateFunctionMap | null)}
    * @memberof OpenAPIRequestValidator
    */
-  public getResponseHeadersValidatorForOperation(operationId: string): ResponseHeadersValidateFunctionMap {
+  public getResponseHeadersValidatorForOperation(operationId: string) {
+    if (this.responseHeadersValidators[operationId] === undefined) {
+      const operation = this.router.getOperation(operationId) as Operation;
+      this.responseHeadersValidators[operationId] = this.buildResponseHeadersValidatorForOperation(operation);
+    }
     return this.responseHeadersValidators[operationId];
   }
 
   /**
-   * Builds an ajv response validator function for an operation and registers it to responseHeadersValidators
+   * Builds an ajv response validator function for an operation and returns it
    *
    * @param {Operation} operation
-   * @memberof OpenAPIRequestValidator
+   * @returns {*}  {(ResponseHeadersValidateFunctionMap | null)}
+   * @memberof OpenAPIValidator
    */
-  public buildResponseHeadersValidatorForOperation(operation: Operation): void {
+  public buildResponseHeadersValidatorForOperation(operation: Operation): ResponseHeadersValidateFunctionMap | null {
     if (!operation || !operation.operationId) {
       // no operationId, don't register a validator
-      return;
+      return null;
     }
     if (!operation.responses) {
       // operation has no responses, don't register a validator
-      return;
+      return null;
     }
 
-    const { operationId } = operation;
     const headerValidators: ResponseHeadersValidateFunctionMap = {};
     const validator = this.getAjv(ValidationContext.ResponseHeaders, { coerceTypes: true });
 
@@ -734,6 +762,28 @@ export class OpenAPIValidator {
       return null;
     });
 
-    this.responseHeadersValidators[operationId] = headerValidators;
+    return headerValidators;
+  }
+
+  /**
+   * Get Ajv options
+   *
+   * @param {ValidationContext} validationContext
+   * @param {Ajv.Options} [opts={}]
+   * @returns Ajv
+   * @memberof OpenAPIValidator
+   */
+  public getAjv(validationContext: ValidationContext, opts: Ajv.Options = {}) {
+    const ajvOpts = { ...this.ajvOpts, ...opts };
+    const ajv = new Ajv(ajvOpts);
+
+    for (const [name, format] of Object.entries(defaultFormats)) {
+      ajv.addFormat(name, format);
+    }
+
+    if (this.customizeAjv) {
+      return this.customizeAjv(ajv, ajvOpts, validationContext);
+    }
+    return ajv;
   }
 }


### PR DESCRIPTION
Closes #114

Adds new constructor option `lazyCompileValidators ` for OpenAPIValidator, which skips precompiling Ajv validators.

This gets applied when OpenAPIBackend is initialised with quick: true.