### PR TITLE
Ensure compatibility with openapi 3.0 and 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",

--- a/src/backend.test.ts
+++ b/src/backend.test.ts
@@ -11,7 +11,7 @@ const responses: OpenAPIV3_1.ResponsesObject = {
 };
 
 const meta = {
-  openapi: '3.0.0',
+  openapi: '3.1.0',
   info: {
     title: 'api',
     version: '1.0.0',

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -60,7 +60,7 @@ const queryFilter: OpenAPIV3_1.ParameterObject = {
 };
 
 const definition: OpenAPIV3_1.Document = {
-  openapi: '3.0.0',
+  openapi: '3.1.0',
   info: {
     title: 'api',
     version: '1.0.0',
@@ -160,7 +160,7 @@ describe('OpenAPIRouter', () => {
 
     test('parses path parameters', () => {
       const request = { path: '/pets/123', method: 'get', headers };
-      const operation = api.getOperation('getPetById');
+      const operation = api.getOperation('getPetById')!;
 
       const parsedRequest = api.parseRequest(request, operation);
       expect(parsedRequest.params).toEqual({ id: '123' });
@@ -195,7 +195,7 @@ describe('OpenAPIRouter', () => {
       const encoded = encodeURI(JSON.stringify(filterValue));
       const request = { path: `/pets?filter=${encoded}`, method: 'get', headers };
 
-      const operation = api.getOperation('getPets') as Operation;
+      const operation = api.getOperation('getPets')!;
       const parsedRequest = api.parseRequest(request, operation);
 
       expect(parsedRequest.query.filter).toEqual(filterValue);
@@ -209,7 +209,7 @@ describe('OpenAPIRouter', () => {
 
     test('parses query string arrays when style=form, explode=false', () => {
       const request = { path: '/pets?limit=10,20', method: 'get', headers };
-      const operation = api.getOperation('createPet') as Operation;
+      const operation = api.getOperation('createPet')!;
       operation.parameters = [
         {
           in: 'query',
@@ -225,7 +225,7 @@ describe('OpenAPIRouter', () => {
 
     test('parses query string arrays when style=spaceDelimited, explode=false', () => {
       const request = { path: '/pets?limit=10%2020', method: 'get', headers };
-      const operation = api.getOperation('createPet') as Operation;
+      const operation = api.getOperation('createPet')!;
       operation.parameters = [
         {
           in: 'query',
@@ -241,7 +241,7 @@ describe('OpenAPIRouter', () => {
 
     test('parses query string arrays when style=pipeDelimited, explode=false', () => {
       const request = { path: '/pets?limit=10|20', method: 'get', headers };
-      const operation = api.getOperation('createPet') as Operation;
+      const operation = api.getOperation('createPet')!;
       operation.parameters = [
         {
           in: 'query',

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,24 +1,34 @@
 import * as _ from 'lodash';
-import type { OpenAPIV3_1 } from 'openapi-types';
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import bath from 'bath-es5';
 import * as cookie from 'cookie';
 import { parse as parseQuery } from 'qs';
 import { Parameters } from 'bath-es5/_/types';
+import { PickVersionElement } from './backend';
 
 // alias Document to OpenAPIV3_1.Document
-type Document = OpenAPIV3_1.Document;
+type Document = OpenAPIV3_1.Document | OpenAPIV3.Document;
+
+/**
+ * OperationObject
+ * @typedef {(OpenAPIV3_1.OperationObject | OpenAPIV3.OperationObject)} OperationObject
+ */
 
 /**
  * OAS Operation Object containing the path and method so it can be placed in a flat array of operations
  *
  * @export
  * @interface Operation
- * @extends {OpenAPIV3_1.OperationObject}
+ * @extends {OperationObject}
  */
-export interface Operation extends OpenAPIV3_1.OperationObject {
+export type Operation<D extends Document = Document> = PickVersionElement<
+  D,
+  OpenAPIV3.OperationObject,
+  OpenAPIV3_1.OperationObject
+> & {
   path: string;
   method: string;
-}
+};
 
 export interface Request {
   method: string;
@@ -53,8 +63,8 @@ export interface ParsedRequest extends Request {
  * @export
  * @class OpenAPIRouter
  */
-export class OpenAPIRouter {
-  public definition: Document;
+export class OpenAPIRouter<D extends Document = Document> {
+  public definition: D;
   public apiRoot: string;
 
   private ignoreTrailingSlashes: boolean;
@@ -63,11 +73,11 @@ export class OpenAPIRouter {
    * Creates an instance of OpenAPIRouter
    *
    * @param opts - constructor options
-   * @param {Document} opts.definition - the OpenAPI definition, file path or Document object
+   * @param {D} opts.definition - the OpenAPI definition, file path or Document object
    * @param {string} opts.apiRoot - the root URI of the api. all paths are matched relative to apiRoot
    * @memberof OpenAPIRouter
    */
-  constructor(opts: { definition: Document; apiRoot?: string; ignoreTrailingSlashes?: boolean }) {
+  constructor(opts: { definition: D; apiRoot?: string; ignoreTrailingSlashes?: boolean }) {
     this.definition = opts.definition;
     this.apiRoot = opts.apiRoot || '/';
     this.ignoreTrailingSlashes = opts.ignoreTrailingSlashes ?? true;
@@ -78,11 +88,11 @@ export class OpenAPIRouter {
    *
    * @param {Request} req
    * @param {boolean} [strict] strict mode, throw error if operation is not found
-   * @returns {Operation }
+   * @returns {Operation<D>}
    * @memberof OpenAPIRouter
    */
-  public matchOperation(req: Request): Operation | undefined;
-  public matchOperation(req: Request, strict: boolean): Operation;
+  public matchOperation(req: Request): Operation<D> | undefined;
+  public matchOperation(req: Request, strict: boolean): Operation<D>;
   public matchOperation(req: Request, strict?: boolean) {
     // normalize request for matching
     req = this.normalizeRequest(req);
@@ -146,25 +156,30 @@ export class OpenAPIRouter {
   /**
    * Flattens operations into a simple array of Operation objects easy to work with
    *
-   * @returns {Operation[]}
+   * @returns {Operation<D>[]}
    * @memberof OpenAPIRouter
    */
-  public getOperations(): Operation[] {
+  public getOperations(): Operation<D>[] {
     const paths = _.get(this.definition, 'paths', {});
     return _.chain(paths)
       .entries()
       .flatMap(([path, pathBaseObject]) => {
         const methods = _.pick(pathBaseObject, ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
         return _.entries(methods).map(([method, operation]) => {
-          const op = operation as OpenAPIV3_1.OperationObject;
+          const op = operation as Operation<D>;
           return {
             ...op,
             path,
             method,
             // append the path base object's parameters to the operation's parameters
             parameters: [
-              ...((op.parameters as OpenAPIV3_1.ParameterObject[]) || []),
-              ...((pathBaseObject?.parameters as OpenAPIV3_1.ParameterObject[]) || []), // path base object parameters
+              ...((op.parameters as PickVersionElement<D, OpenAPIV3.ParameterObject, OpenAPIV3_1.ParameterObject>[]) ||
+                []),
+              ...((pathBaseObject?.parameters as PickVersionElement<
+                D,
+                OpenAPIV3.ParameterObject,
+                OpenAPIV3_1.ParameterObject
+              >[]) || []), // path base object parameters
             ],
             // operation-specific security requirement override global requirements
             security: op.security || this.definition.security || [],
@@ -178,10 +193,10 @@ export class OpenAPIRouter {
    * Gets a single operation based on operationId
    *
    * @param {string} operationId
-   * @returns {Operation}
+   * @returns {Operation<D>}
    * @memberof OpenAPIRouter
    */
-  public getOperation(operationId: string): Operation | undefined {
+  public getOperation(operationId: string): Operation<D> | undefined {
     return _.find(this.getOperations(), { operationId });
   }
 
@@ -246,10 +261,11 @@ export class OpenAPIRouter {
    *
    * @export
    * @param {Request} req
+   * @param {Operation<D>} [operation]
    * @param {string} [patbh]
    * @returns {ParsedRequest}
    */
-  public parseRequest(req: Request, operation?: Operation): ParsedRequest {
+  public parseRequest(req: Request, operation?: Operation<D>): ParsedRequest {
     let requestBody = req.body;
     if (req.body && typeof req.body !== 'object') {
       try {
@@ -286,10 +302,14 @@ export class OpenAPIRouter {
       // parse query parameters with specified style for parameter
       for (const queryParam in query) {
         if (query[queryParam]) {
-          const parameter = _.find((operation.parameters as OpenAPIV3_1.ParameterObject[]) || [], {
-            name: queryParam,
-            in: 'query',
-          });
+          const parameter = _.find(
+            (operation.parameters as PickVersionElement<D, OpenAPIV3.ParameterObject, OpenAPIV3_1.ParameterObject>[]) ||
+              [],
+            {
+              name: queryParam,
+              in: 'query',
+            },
+          );
           if (parameter) {
             if (parameter.content && parameter.content['application/json']) {
               query[queryParam] = JSON.parse(query[queryParam]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
 import * as _ from 'lodash';
+import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import { Operation } from './router';
+
+// alias Document to OpenAPIV3_1.Document
+type Document = OpenAPIV3_1.Document | OpenAPIV3.Document;
 
 export default class OpenAPIUtils {
   /**
@@ -79,11 +83,11 @@ export default class OpenAPIUtils {
    * Get operationId, (or generate one) for an operation
    *
    * @static
-   * @param {Operation} operation
+   * @param {Operation<D>} operation
    * @returns {string} OperationId of the given operation
    * @memberof OpenAPIUtils
    */
-  public static getOperationId(operation: Operation): string {
+  public static getOperationId<D extends Document = Document>(operation: Operation<D>): string {
     if (!operation?.operationId) {
       // TODO: generate a default substitute for operationId
       return `unknown`;

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -12,7 +12,7 @@ const circularRefPath = path.join(testsDir, 'resources', 'refs.openapi.json');
 const headers = { accept: 'application/json' };
 
 const meta: OpenAPIV3_1.Document = {
-  openapi: '3.0.0',
+  openapi: '3.1.0',
   info: {
     title: 'api',
     version: '1.0.0',


### PR DESCRIPTION
Since #212 has added support for openapi 3.1, openapi-backend types stopped working with openapi 3.0 types.

This PR ensures that both openapi 3.0 and 3.1 types are supported.

@anttiviljami please review this PR and check if everything works as expected