### PR TITLE
Validation of a 204 response with an empty body

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -643,6 +643,28 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
                 },
               },
             },
+            delete: {
+              operationId: 'deletePetById',
+              responses: {
+                204: {
+                  description: 'a pet',
+                },
+                default: {
+                  description: 'pet not found',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          err: { type: 'string' },
+                        },
+                        required: ['err'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
             parameters: [
               {
                 name: 'id',
@@ -810,6 +832,19 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
       );
       expect(valid.errors).toBeTruthy();
     });
+
+    test('passes validation with valid 204 containing no body when there is a default response', async () => {
+      const valid = validator.validateResponse(
+        null,
+        {
+          method: 'delete',
+          path: '/pets/{id}',
+          operationId: 'deletePetById',
+        },
+        204,
+      );
+      expect(valid.errors).toBeFalsy();
+    })
   });
 
   describe('.validateResponseHeaders', () => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -749,16 +749,16 @@ export class OpenAPIValidator<D extends Document = Document> {
         responseValidators[status] = OpenAPIValidator.compileSchema(validator, validateFn);
       }
 
-      if (!response.content && status === "204") {
+      if (!response.content && status === '204') {
         const validateFn = {
-          type: "null",
-          title: "The root schema",
-          description: "The root schema comprises the entire JSON document.",
+          type: 'null',
+          title: 'The root schema',
+          description: 'The root schema comprises the entire JSON document.',
           default: null,
         };
         responseValidators[status] = OpenAPIValidator.compileSchema(validator, validateFn);
       }
-      
+
       return null;
     });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -748,6 +748,17 @@ export class OpenAPIValidator<D extends Document = Document> {
         const validateFn = response.content['application/json'].schema;
         responseValidators[status] = OpenAPIValidator.compileSchema(validator, validateFn);
       }
+
+      if (!response.content && status === "204") {
+        const validateFn = {
+          type: "null",
+          title: "The root schema",
+          description: "The root schema comprises the entire JSON document.",
+          default: null,
+        };
+        responseValidators[status] = OpenAPIValidator.compileSchema(validator, validateFn);
+      }
+      
       return null;
     });
 


### PR DESCRIPTION
Creates a null document validator, when the response is a 204 status code. This should fix #301 in which 204 responses without bodies are incorrectly failing response validation when also used with a default response.