### PR TITLE
Add support for preRequesthandler

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -114,6 +114,7 @@ export class OpenAPIBackend<D extends Document = Document> {
     'validationFail',
     'unauthorizedHandler',
     'postResponseHandler',
+    'preRequestHandler'
   ];
 
   public securityHandlers: { [name: string]: Handler };
@@ -388,6 +389,12 @@ export class OpenAPIBackend<D extends Document = Document> {
           throw Error(`501-notImplemented: ${operationId} no handler registered`);
         }
         return notImplementedHandler(context as Context<D>, ...handlerArgs);
+      }
+
+      // pre request handler
+      const preRequestHandler: Handler = this.handlers['preRequestHandler'];
+      if (preRequestHandler) {
+        preRequestHandler(context as Context<D>, ...handlerArgs);
       }
 
       // handle route


### PR DESCRIPTION
preRequestHandler if registered will be invoked just before the handler. I would like to be able to run some code for all handlers before they execute without the need to duplicate the code in handlers.