### PR TITLE
feat: add support to pass array query parameters

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -223,8 +223,40 @@ describe('OpenAPIRouter', () => {
       expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
     });
 
+    test('parses query parameter arrays when style=form, explode=false', () => {
+      const request = { path: '/pets', query: { limit: '10,20' }, method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'limit',
+          style: 'form',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request, operation);
+      expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
+    });
+
     test('parses query string arrays with encoded commas when style=form, explode=false', () => {
       const request = { path: '/pets?limit=10%2C20', method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'limit',
+          style: 'form',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request, operation);
+      expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
+    });
+
+    test('parses query parameter arrays with encoded commas when style=form, explode=false', () => {
+      const request = { path: '/pets', query: { limit: '10%2C20' }, method: 'get', headers };
       const operation = api.getOperation('createPet')!;
       operation.parameters = [
         {
@@ -255,8 +287,40 @@ describe('OpenAPIRouter', () => {
       expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
     });
 
+    test('parses query parameter arrays when style=spaceDelimited, explode=false', () => {
+      const request = { path: '/pets', query: { limit: '10%2020' }, method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'limit',
+          style: 'spaceDelimited',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request, operation);
+      expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
+    });
+
     test('parses query string arrays when style=pipeDelimited, explode=false', () => {
       const request = { path: '/pets?limit=10|20', method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'limit',
+          style: 'pipeDelimited',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request, operation);
+      expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
+    });
+
+    test('parses query parameter arrays when style=pipeDelimited, explode=false', () => {
+      const request = { path: '/pets', query: { limit: '10|20' }, method: 'get', headers };
       const operation = api.getOperation('createPet')!;
       operation.parameters = [
         {

--- a/src/router.ts
+++ b/src/router.ts
@@ -320,6 +320,15 @@ export class OpenAPIRouter<D extends Document = Document> {
               // use comma parsing e.g. &a=1,2,3
               const commaParsed = parseQuery(commaQueryString, { comma: true });
               query[queryParam] = commaParsed[queryParam];
+            } else if(parameter.explode === false) {
+              let decoded = query[queryParam].replace(/\%2C/g, ',');
+              if (parameter.style === 'spaceDelimited') {
+                decoded = decoded.replace(/\ /g, ',').replace(/\%20/g, ',');
+              }
+              if (parameter.style === 'pipeDelimited') {
+                decoded = decoded.replace(/\|/g, ',').replace(/\%7C/g, ',');
+              }
+              query[queryParam] = decoded.split(',');
             }
           }
         }


### PR DESCRIPTION
This is missing feature that does not work for example in AWS Lambda where the query parameters are inputted in query object from ALB Event's queryStringParameters object. Also AWS lambda passes the query parameters to the handler encoded so decoding must be done for the parameters.