### PR TITLE
Fix query coercion issue

### DIFF
--- a/src/backend.test.ts
+++ b/src/backend.test.ts
@@ -44,6 +44,30 @@ describe('OpenAPIBackend', () => {
       '/pets/{id}': {
         get: {
           operationId: 'getPetById',
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string'
+              }
+            },
+            {
+              name: 'breed',
+              in: 'query',
+              schema: {
+                type: 'string'
+              }
+            },
+            {
+              name: 'age',
+              in: 'query',
+              schema: {
+                type: 'integer'
+              }
+            }
+          ],
           responses,
         },
         put: {
@@ -466,6 +490,30 @@ describe('OpenAPIBackend', () => {
         expect(mockHandler).toBeCalled();
       });
     });
+
+    describe('types coercion', () => {
+      test('coerces query types', async () => {
+        const api = new OpenAPIBackend({ definition });
+        const dummyHandler = jest.fn((context, req, ...rest) => req);
+        api.register('getPetById', dummyHandler);
+        await api.init();
+
+        const request = {
+          method: 'get',
+          path: '/pets/1',
+          headers: {},
+          query: {
+              breed: 'corgi',
+              age: '5',
+          }
+        };
+
+        const res = await api.handleRequest(request);
+        expect(dummyHandler).toBeCalledTimes(1);
+
+        expect(res.query).toStrictEqual({breed: 'corgi', age: 5});
+      });
+    })
   });
 
   describe('.mockResponseForOperation', () => {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -421,7 +421,7 @@ export class OpenAPIBackend<D extends Document = Document> {
       }
 
       // handle route
-      return routeHandler(context as Context<D>, ...handlerArgs);
+      return routeHandler(context as Context<D>, req, ...handlerArgs);
     }).bind(this)();
 
     // post response handler

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -307,6 +307,10 @@ export class OpenAPIValidator<D extends Document = Document> {
       if (validate.errors) {
         result.errors.push(...validate.errors);
       }
+      else {
+        // set Ajv validator coerced query to request
+        req.query = parameters.query
+      }
     }
 
     if (_.isEmpty(result.errors)) {


### PR DESCRIPTION
Fixed #554

Note that query parameters are coerced just fine by Ajv validators. But `parameters.query` is never assigned back to original request that is passed down to handlers.  

However, this might be not desirable behaviour by default. Maybe it is better to add additional option on OpenAPIBackend initialization to allow modifying data during validation like this:

```
  const api = new OpenAPIBackend({
    definition: "./open-api-spec.json",
    validate: true,
    **modifyReqData: true**,
    ajvOpts: {
      coerceTypes: true
    }
    ...
  })
```

Pls let me know what you think.