### PR TITLE
fix parseRequest in case of type coercion and array query-params

### DIFF
--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -336,6 +336,38 @@ describe('OpenAPIRouter', () => {
       const parsedRequest = api.parseRequest(request, operation);
       expect(parsedRequest.query).toEqual({ limit: ['10', '20'] });
     });
+
+    test('parses already-coerced array query param with multiple string elements', () => {
+      const request = { path: '/pets', query: { keywords: ['hello', 'world'] }, method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'keywords',
+          style: 'spaceDelimited',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request as any, operation);
+      expect(parsedRequest.query).toEqual({ keywords: ['hello', 'world'] });
+    });
+
+    test('parses already-coerced array query param with a single non-string element', () => {
+      const request = { path: '/pets', query: { limit: [10] }, method: 'get', headers };
+      const operation = api.getOperation('createPet')!;
+      operation.parameters = [
+        {
+          in: 'query',
+          name: 'limit',
+          style: 'spaceDelimited',
+          explode: false,
+        },
+      ];
+
+      const parsedRequest = api.parseRequest(request as any, operation);
+      expect(parsedRequest.query).toEqual({ limit: [10] });
+    });
   });
 
   describe('.matchOperation', () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -327,7 +327,15 @@ export class OpenAPIRouter<D extends Document = Document> {
               }
             } else if (parameter.explode === false) {
               // Handle parameter parsing for non-exploded arrays
-              const value = Array.isArray(query[queryParam]) ? query[queryParam][0] : query[queryParam];
+              const rawValue = query[queryParam];
+              if (Array.isArray(rawValue) && rawValue.length > 1) {
+                // param has already been decoded (type coercion flow)
+                continue;
+              }
+              const value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+              if (typeof value !== 'string') {
+                continue;
+              }
               let decoded = value.replace(/%2C/g, ',');
               if (parameter.style === 'spaceDelimited') {
                 decoded = decoded.replace(/ /g, ',').replace(/%20/g, ',');


### PR DESCRIPTION
Hello,

This PR fixes two problems that occur when type coercion is enabled and the query contains array params:

 - when the array elements are not strings, ParseRequest fails with this error:
 `TypeError: value.replace is not a function
    at OpenAPIRouter.parseRequest (/app/node_modules/openapi-backend/router.js:252:49)
    at OpenAPIBackend.<anonymous> (/app/node_modules/openapi-backend/backend.js:350:51)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async OpenAPIBackend.handleRequest (/app/node_modules/openapi-backend/backend.js:227:26)`

 - when the array elements are strings, ParseRequest keeps only the first one.
 
 I added two unit tests to cover these scenarios.