### PR TITLE
5.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-backend",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-backend",
-      "version": "5.17.0",
+      "version": "5.18.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-backend",
   "description": "Build, Validate, Route, Authenticate and Mock using OpenAPI definitions. Framework-agnostic",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "author": "Viljami Kuosmanen <viljami@viljami.io>",
   "funding": "https://github.com/sponsors/anttiviljami",
   "license": "MIT",


### PR DESCRIPTION
Minor version bump to **5.18.0**, created with `npm version minor` (commit message and tag name are the bare version per the repo's `.npmrc` `tag-version-prefix=""`).

Includes the merged fail-open authorization fix (#919): a security handler returning a multi-key error object such as `{ error, user: null }` is now correctly treated as a failed auth.

### Why this is a PR instead of a direct push + tag

The release was requested as "bump a minor and push the tag." `npm version minor` ran cleanly and produced the `5.18.0` commit and annotated tag locally, but this session's credentials cannot push to protected refs — both `git push origin main` and `git push origin 5.18.0` return HTTP 403 (branch/tag protection). Merging this PR lands the bump on `main`; the `5.18.0` tag / GitHub Release then needs to be created by a maintainer (or via the GitHub Releases UI), since the tag push is likewise blocked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XVCan3Y52cYZ6WghjZwrw

---
_Generated by [Claude Code](https://claude.ai/code/session_012XVCan3Y52cYZ6WghjZwrw)_