### PR TITLE
fix: honor optional request bodies

### DIFF
--- a/src/backend.test.ts
+++ b/src/backend.test.ts
@@ -415,6 +415,74 @@ describe('OpenAPIBackend', () => {
         expect(context.security?.authorized).toBe(true);
       });
 
+      test('sets context.security.authorized=true for an api key search operation', async () => {
+        const xquikDefinition: OpenAPIV3_1.Document = {
+          ...meta,
+          paths: {
+            '/api/v1/x/tweets/search': {
+              get: {
+                operationId: 'searchTweets',
+                parameters: [
+                  {
+                    name: 'q',
+                    in: 'query',
+                    required: true,
+                    schema: { type: 'string' },
+                  },
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    required: false,
+                    schema: { type: 'integer', default: 20, maximum: 200 },
+                  },
+                ],
+                security: [{ apiKey: [] }, { oauthBearer: [] }, {}],
+                responses,
+              },
+            },
+          },
+          components: {
+            securitySchemes: {
+              apiKey: {
+                type: 'apiKey',
+                in: 'header',
+                name: 'x-api-key',
+              },
+              oauthBearer: {
+                type: 'http',
+                scheme: 'bearer',
+              },
+            },
+          },
+        };
+        const api = new OpenAPIBackend({ definition: xquikDefinition });
+        let context: Partial<Context> = {};
+        api.register('searchTweets', (c) => {
+          context = c;
+          return {
+            tweets: [],
+            has_next_page: false,
+            next_cursor: '',
+          };
+        });
+        api.registerSecurityHandler('apiKey', (c) => c.request.headers['x-api-key'] === 'test-key');
+
+        await api.init();
+        const result = await api.handleRequest({
+          method: 'get',
+          path: '/api/v1/x/tweets/search?q=openapi',
+          headers: { 'x-api-key': 'test-key' },
+        });
+
+        expect(result).toEqual({
+          tweets: [],
+          has_next_page: false,
+          next_cursor: '',
+        });
+        expect(context.security?.apiKey).toBe(true);
+        expect(context.security?.authorized).toBe(true);
+      });
+
       test('sets context.security.authorized=false if security requirements not met', async () => {
         const api = new OpenAPIBackend({ definition });
         let context: Partial<Context> = {};

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -497,6 +497,7 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
                   operationId: 'createPet',
                   responses: { 200: { description: 'ok' } },
                   requestBody: {
+                    required: true,
                     content: {
                       'application/json': {
                         schema: petSchema,
@@ -514,6 +515,19 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
                       },
                       'application/xml': {
                         example: '<Pet><name>string</name></Pet>',
+                      },
+                    },
+                  },
+                },
+              },
+              '/pets/optional': {
+                post: {
+                  operationId: 'createOptionalPet',
+                  responses: { 200: { description: 'ok' } },
+                  requestBody: {
+                    content: {
+                      'application/json': {
+                        schema: petSchema,
                       },
                     },
                   },
@@ -629,6 +643,15 @@ describe.each([{}, { lazyCompileValidators: true }])('OpenAPIValidator with opts
           headers,
         });
         expect(valid.errors).toHaveLength(1);
+      });
+
+      test('passes validation with an omitted optional request body', async () => {
+        const valid = validator.validateRequest({
+          path: '/pets/optional',
+          method: 'post',
+          headers,
+        });
+        expect(valid.errors).toBeFalsy();
       });
 
       test('fails validation for non-json data when the only media type defined is application/json', async () => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -578,8 +578,7 @@ export class OpenAPIValidator<D extends Document = Document> {
           },
         };
         requestBodySchema.required = [];
-        if (_.keys(requestBody.content).length === 1) {
-          // if application/json is the only specified format, it's required
+        if (requestBody.required === true) {
           requestBodySchema.required.push('requestBody');
         }
 


### PR DESCRIPTION
## Summary

- Add an OpenAPI 3.1 security fixture based on Xquik's public `searchTweets` contract.
- Verify a registered `apiKey` handler authorizes the canonical `x-api-key` header.
- Honor `requestBody.required` instead of inferring required bodies from media-type count.
- Add regression coverage for omitted optional request bodies.

The request-body fix also resolves #817 and its earlier duplicate #292.

## Validation

- `npm ci`
- `NODE_ENV=test jest --runInBand` (294 tests)
- `npm run build`
- `npm run lint`
- `npx prettier --check src/validation.ts src/validation.test.ts src/backend.test.ts`
- `git diff --check`
